### PR TITLE
Add MoviePageView for timeline pages

### DIFF
--- a/Views/MoviePageView.swift
+++ b/Views/MoviePageView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct MoviePageView: View {
+    let movie: Movie
+
+    var body: some View {
+        VStack(spacing: 16) {
+            AsyncImage(url: URL(string: movie.imageURL)) { image in
+                image
+                    .resizable()
+                    .scaledToFit()
+            } placeholder: {
+                ZStack {
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.3))
+                    Image(systemName: "film")
+                        .font(.largeTitle)
+                        .foregroundColor(.gray)
+                }
+            }
+            .frame(maxHeight: 300)
+
+            Text(movie.title)
+                .font(.title)
+                .multilineTextAlignment(.center)
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+struct MoviePageView_Previews: PreviewProvider {
+    static var previews: some View {
+        MoviePageView(
+            movie: Movie(id: "1", title: "Sample Movie", imageURL: "https://example.com/poster.jpg", releaseYear: 2024, sortOrder: 1)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add `MoviePageView` to show a movie poster placeholder and title
- include a preview with sample movie data

## Testing
- `swift test -v` *(fails: Package.swift missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e6ce9f6a0832186597000092e5eda