### PR TITLE
Add PageCurlView coordinator tests

### DIFF
--- a/MelodyMapTests/PageCurlViewTests.swift
+++ b/MelodyMapTests/PageCurlViewTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+import SwiftUI
+@testable import MelodyMap
+
+final class PageCurlViewTests: XCTestCase {
+    func testCoordinatorCreatesViewControllersForMovies() {
+        let movies: [Movie] = [
+            Movie(id: "1", title: "One", imageURL: "", releaseYear: 2000, sortOrder: 0),
+            Movie(id: "2", title: "Two", imageURL: "", releaseYear: 2001, sortOrder: 1),
+            Movie(id: "3", title: "Three", imageURL: "", releaseYear: 2002, sortOrder: 2)
+        ]
+        let view = PageCurlView(movies: movies)
+        let coordinator = PageCurlView.Coordinator(parent: view)
+        let controllers = movies.map { coordinator.controller(for: $0) }
+        let uniqueIdentifiers = Set(controllers.map { ObjectIdentifier($0) })
+        XCTAssertEqual(uniqueIdentifiers.count, movies.count)
+    }
+}


### PR DESCRIPTION
## Summary
- add `PageCurlViewTests` verifying coordinator manages view controller count

## Testing
- `swiftc MelodyMapTests/PageCurlViewTests.swift -o /tmp/test` *(fails: no such module 'SwiftUI')*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684e6d666e10832197782fe6ccbb448e