### PR TITLE
Fix search text field style

### DIFF
--- a/Views/SearchView.swift
+++ b/Views/SearchView.swift
@@ -7,7 +7,7 @@ struct SearchView: View {
         NavigationView {
             VStack {
                 TextField("Search", text: $vm.query)
-                    .searchFieldStyle(.roundedBorder)
+                    .textFieldStyle(.roundedBorder)
                     .padding([.horizontal, .top])
                     .onChange(of: vm.query) { _ in vm.search() }
 


### PR DESCRIPTION
## Summary
- use `textFieldStyle` instead of the non-existent `searchFieldStyle`

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e77c896ec832189452256e97f5853