### PR TITLE
Add draggable timeline for movie songs

### DIFF
--- a/MelodyMapTests/PageCurlViewTests.swift
+++ b/MelodyMapTests/PageCurlViewTests.swift
@@ -9,7 +9,7 @@ final class PageCurlViewTests: XCTestCase {
             Movie(id: "2", title: "Two", imageURL: "", releaseYear: 2001, sortOrder: 1),
             Movie(id: "3", title: "Three", imageURL: "", releaseYear: 2002, sortOrder: 2)
         ]
-        let view = PageCurlView(movies: movies)
+        let view = PageCurlView(movies: movies, songs: [])
         let coordinator = PageCurlView.Coordinator(parent: view)
         let controllers = movies.map { coordinator.controller(for: $0) }
         let uniqueIdentifiers = Set(controllers.map { ObjectIdentifier($0) })

--- a/Views/MoviePageView.swift
+++ b/Views/MoviePageView.swift
@@ -2,38 +2,90 @@ import SwiftUI
 
 struct MoviePageView: View {
     let movie: Movie
+    let songs: [Song]
+
+    private var songsForMovie: [Song] {
+        songs.filter { $0.movieId == movie.id }
+    }
 
     var body: some View {
-        VStack(spacing: 16) {
-            AsyncImage(url: URL(string: movie.imageURL)) { image in
-                image
-                    .resizable()
-                    .scaledToFit()
-            } placeholder: {
-                ZStack {
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.3))
-                    Image(systemName: "film")
-                        .font(.largeTitle)
-                        .foregroundColor(.gray)
+        ScrollViewReader { proxy in
+            VStack(spacing: 16) {
+                AsyncImage(url: URL(string: movie.imageURL)) { image in
+                    image
+                        .resizable()
+                        .scaledToFit()
+                } placeholder: {
+                    ZStack {
+                        Rectangle()
+                            .fill(Color.gray.opacity(0.3))
+                        Image(systemName: "film")
+                            .font(.largeTitle)
+                            .foregroundColor(.gray)
+                    }
                 }
-            }
-            .frame(height: 200)
+                .frame(height: 200)
 
-            Text(movie.title)
-                .font(.title2)
-                .padding(.top, 8)
-                .multilineTextAlignment(.center)
-            Spacer()
+                GeometryReader { geo in
+                    ZStack(alignment: .topLeading) {
+                        Rectangle()
+                            .frame(height: 2)
+                            .foregroundColor(.secondary)
+                        ForEach(songsForMovie) { song in
+                            Circle()
+                                .frame(width: 12, height: 12)
+                                .position(x: geo.size.width * CGFloat(song.percent) / 100,
+                                          y: 1)
+                        }
+                    }
+                    .gesture(
+                        DragGesture()
+                            .onEnded { value in
+                                let ratio = min(max(0, value.location.x / geo.size.width), 1)
+                                let nearest = songsForMovie.min {
+                                    abs(ratio - CGFloat($0.percent) / 100) <
+                                    abs(ratio - CGFloat($1.percent) / 100)
+                                }
+                                if let nearest = nearest {
+                                    withAnimation {
+                                        proxy.scrollTo(nearest.id, anchor: .top)
+                                    }
+                                }
+                            }
+                    )
+                }
+                .frame(height: 12)
+
+                Text(movie.title)
+                    .font(.title2)
+                    .padding(.top, 8)
+                    .multilineTextAlignment(.center)
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(songsForMovie) { song in
+                            Text(song.title)
+                                .id(song.id)
+                                .padding(.vertical, 4)
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+
+                Spacer()
+            }
+            .padding()
         }
-        .padding()
     }
 }
 
 struct MoviePageView_Previews: PreviewProvider {
     static var previews: some View {
         MoviePageView(
-            movie: Movie(id: "1", title: "Sample Movie", imageURL: "https://example.com/poster.jpg", releaseYear: 2024, sortOrder: 1)
+            movie: Movie(id: "1", title: "Sample Movie", imageURL: "https://example.com/poster.jpg", releaseYear: 2024, sortOrder: 1),
+            songs: [
+                Song(id: "song1", movieId: "1", title: "First", percent: 10, startTime: "00:01:00", singers: [], releaseYear: 2024, movieRuntimeMinutes: 90, streamingLinks: [], purchaseLinks: [], keywords: [], blurb: "")
+            ]
         )
     }
 }

--- a/Views/PageCurlView.swift
+++ b/Views/PageCurlView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PageCurlView: UIViewControllerRepresentable {
     var movies: [Movie]
+    var songs: [Song]
 
     func makeCoordinator() -> Coordinator {
         Coordinator(parent: self)
@@ -41,7 +42,8 @@ struct PageCurlView: UIViewControllerRepresentable {
 
         func controller(for movie: Movie) -> UIViewController {
             if let cached = cache[movie.id] { return cached }
-            let vc = UIHostingController(rootView: MoviePageView(movie: movie))
+            let songsForMovie = parent.songs.filter { $0.movieId == movie.id }
+            let vc = UIHostingController(rootView: MoviePageView(movie: movie, songs: songsForMovie))
             cache[movie.id] = vc
             return vc
         }

--- a/Views/TimelineView.swift
+++ b/Views/TimelineView.swift
@@ -4,7 +4,7 @@ struct TimelineView: View {
     @StateObject private var viewModel = TimelineViewModel()
 
     var body: some View {
-        PageCurlView(movies: viewModel.movies)
+        PageCurlView(movies: viewModel.movies, songs: viewModel.songs)
             .onAppear {
                 viewModel.load()
             }


### PR DESCRIPTION
## Summary
- inject `songs` into `PageCurlView` and `MoviePageView`
- draw song markers and add drag-to-snap gesture in `MoviePageView`
- pass songs from `TimelineView`
- adjust unit test for `PageCurlView` constructor

## Testing
- `xcodebuild test -scheme MelodyMap -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f05119120832195e36a2bd10f2c07