### PR TITLE
Implement collapsed song panel with navigation

### DIFF
--- a/Views/StarButton.swift
+++ b/Views/StarButton.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct StarButton: View {
+    @State private var isStarred = false
+
+    var body: some View {
+        Button(action: { isStarred.toggle() }) {
+            Image(systemName: isStarred ? "star.fill" : "star")
+                .foregroundColor(.yellow)
+        }
+        .buttonStyle(.plain)
+        .frame(width: 44, height: 44)
+    }
+}
+
+struct StarButton_Previews: PreviewProvider {
+    static var previews: some View {
+        StarButton()
+    }
+}


### PR DESCRIPTION
## Summary
- add `StarButton` reusable control
- embed arrow buttons in `MoviePageView` for moving between songs
- show collapsed song panel with timing, title, movie info, and character list

## Testing
- `swift test --enable-test-discovery` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684f07673d54832182bfd2d1b59d543a