### PR TITLE
Add usage meter overlay

### DIFF
--- a/MelodyMapApp.swift
+++ b/MelodyMapApp.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 @main
 struct MelodyMapApp: App {
+    @StateObject private var usageTracker = UsageTrackerService.shared
     var body: some Scene {
         WindowGroup {
             MainTabView()
+                .environmentObject(usageTracker)
         }
     }
 }

--- a/Services/UsageTrackerService.swift
+++ b/Services/UsageTrackerService.swift
@@ -9,6 +9,9 @@ final class UsageTrackerService: ObservableObject {
     private let dateKey = "UsageTrackerService.lastDate"
     private let remainingKey = "UsageTrackerService.remaining"
 
+    /// Public accessor for the daily quota limit.
+    var quota: Int { baseQuota }
+
     @Published private(set) var remaining: Int = 0
 
     private init() {

--- a/Views/SearchView.swift
+++ b/Views/SearchView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SearchView: View {
     @StateObject private var vm = SearchViewModel()
+    @EnvironmentObject private var usage: UsageTrackerService
 
     var body: some View {
         NavigationView {
@@ -25,11 +26,16 @@ struct SearchView: View {
             }
             .navigationTitle("Search")
         }
+        .overlay(alignment: .topTrailing) {
+            UsageMeterView()
+                .padding()
+        }
     }
 }
 
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {
         SearchView()
+            .environmentObject(UsageTrackerService.shared)
     }
 }

--- a/Views/TimelineView.swift
+++ b/Views/TimelineView.swift
@@ -2,11 +2,16 @@ import SwiftUI
 
 struct TimelineView: View {
     @StateObject private var viewModel = TimelineViewModel()
+    @EnvironmentObject private var usage: UsageTrackerService
 
     var body: some View {
         PageCurlView(movies: viewModel.movies, songs: viewModel.songs)
             .onAppear {
                 viewModel.load()
+            }
+            .overlay(alignment: .topTrailing) {
+                UsageMeterView()
+                    .padding()
             }
     }
 }
@@ -14,5 +19,6 @@ struct TimelineView: View {
 struct TimelineView_Previews: PreviewProvider {
     static var previews: some View {
         TimelineView()
+            .environmentObject(UsageTrackerService.shared)
     }
 }

--- a/Views/UsageMeterView.swift
+++ b/Views/UsageMeterView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct UsageMeterView: View {
+    @EnvironmentObject private var tracker: UsageTrackerService
+
+    var body: some View {
+        ZStack {
+            ProgressView(value: Double(tracker.remaining), total: Double(tracker.quota))
+                .progressViewStyle(.circular)
+                .frame(width: 24, height: 24)
+            Text("\(tracker.remaining)/\(tracker.quota)")
+                .font(.caption2)
+        }
+    }
+}
+
+struct UsageMeterView_Previews: PreviewProvider {
+    static var previews: some View {
+        UsageMeterView()
+            .environmentObject(UsageTrackerService.shared)
+    }
+}


### PR DESCRIPTION
## Summary
- expose the daily quota in `UsageTrackerService`
- add `UsageMeterView` displaying a circular progress ring and remaining quota
- overlay `UsageMeterView` on `SearchView` and `TimelineView`
- inject `UsageTrackerService` in `MelodyMapApp`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684f10d7260c83219a15e26f975e30f0