### PR TITLE
Fix InAppPurchaseService observable object conformance

### DIFF
--- a/Services/InAppPurchaseService.swift
+++ b/Services/InAppPurchaseService.swift
@@ -1,6 +1,8 @@
 import Foundation
+import Combine
 
-final class InAppPurchaseService {
+@MainActor
+final class InAppPurchaseService: ObservableObject {
     static let shared = InAppPurchaseService()
 
     func purchaseMonthly() {


### PR DESCRIPTION
## Summary
- make `InAppPurchaseService` an `ObservableObject`
- annotate the service with `@MainActor`
- import Combine

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_684fbb1e12b88321a6a4fe3d77d2c63e