### PR TITLE
Add ad service implementation

### DIFF
--- a/Services/AdService.swift
+++ b/Services/AdService.swift
@@ -1,11 +1,63 @@
 import Foundation
 import Combine
+import GoogleMobileAds
 
 @MainActor
 final class AdService: ObservableObject {
     static let shared = AdService()
 
+    private let adUnitID = "ca-app-pub-3940256099942544/1712485313"
+
+    private var rewardedAd: GADRewardedAd?
+    private var rewardCompletion: ((Bool) -> Void)?
+
+    private init() {
+        loadAd()
+    }
+
     func loadAd() {
-        // TODO: Implement ad loading
+        GADRewardedAd.load(withAdUnitID: adUnitID, request: GADRequest()) { [weak self] ad, error in
+            if let ad = ad {
+                self?.rewardedAd = ad
+            } else {
+                print("Failed to load rewarded ad: \(error?.localizedDescription ?? "unknown error")")
+                self?.rewardedAd = nil
+            }
+        }
+    }
+
+    func presentAd(from rootVC: UIViewController, onEarned: @escaping (Bool) -> Void) {
+        guard let ad = rewardedAd else {
+            onEarned(false)
+            loadAd()
+            return
+        }
+        rewardCompletion = onEarned
+        ad.fullScreenContentDelegate = self
+        ad.present(fromRootViewController: rootVC) { [weak self] in
+            self?.rewardCompletion?(true)
+            self?.rewardCompletion = nil
+            self?.rewardedAd = nil
+            self?.loadAd()
+        }
+    }
+}
+
+extension AdService: GADFullScreenContentDelegate {
+    func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        rewardCompletion?(false)
+        rewardCompletion = nil
+        rewardedAd = nil
+        loadAd()
+    }
+
+    func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+        if rewardCompletion != nil {
+            // Ad dismissed without reward
+            rewardCompletion?(false)
+            rewardCompletion = nil
+        }
+        rewardedAd = nil
+        loadAd()
     }
 }

--- a/Views/ProfileView.swift
+++ b/Views/ProfileView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct ProfileView: View {
     @StateObject private var viewModel = UserProfileViewModel()
+    @EnvironmentObject private var tracker: UsageTrackerService
+    @EnvironmentObject private var adService: AdService
+    @State private var loadingAd = false
 
     var body: some View {
         Form {
@@ -9,7 +12,18 @@ struct ProfileView: View {
                 Text(viewModel.isSubscribed ? "Subscribed" : "Free User")
             }
             Section(header: Text("Daily Uses")) {
-                Text("Remaining: \(viewModel.dailyUsesRemaining)")
+                Text("Remaining: \(tracker.remaining)")
+                Button("Watch Ad to Extend") {
+                    guard let root = UIApplication.shared.connectedScenes
+                        .compactMap({ ($0 as? UIWindowScene)?.windows.first { $0.isKeyWindow } })
+                        .first?.rootViewController else { return }
+                    loadingAd = true
+                    adService.presentAd(from: root) { success in
+                        if success { tracker.addRewarded(2) }
+                        loadingAd = false
+                    }
+                }
+                .disabled(loadingAd)
             }
         }
         .navigationTitle("Profile")
@@ -19,5 +33,7 @@ struct ProfileView: View {
 struct ProfileView_Previews: PreviewProvider {
     static var previews: some View {
         ProfileView()
+            .environmentObject(UsageTrackerService.shared)
+            .environmentObject(AdService.shared)
     }
 }


### PR DESCRIPTION
## Summary
- implement rewarded ad loading and presentation logic
- expose ad viewing in ProfileView so quota can be extended

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684fbd6d82d48321a067104ae3524218