### PR TITLE
Fix AdService delegate implementation

### DIFF
--- a/Services/AdService.swift
+++ b/Services/AdService.swift
@@ -3,7 +3,7 @@ import Combine
 import GoogleMobileAds
 
 @MainActor
-final class AdService: ObservableObject {
+final class AdService: NSObject, ObservableObject {
     static let shared = AdService()
 
     private let adUnitID = "ca-app-pub-3940256099942544/1712485313"
@@ -44,59 +44,8 @@ final class AdService: ObservableObject {
 }
 
 extension AdService: FullScreenContentDelegate {
-    func isEqual(_ object: Any?) -> Bool {
-        <#code#>
-    }
-    
-    var hash: Int {
-        <#code#>
-    }
-    
-    var superclass: AnyClass? {
-        <#code#>
-    }
-    
-    func `self`() -> Self {
-        <#code#>
-    }
-    
-    func perform(_ aSelector: Selector!) -> Unmanaged<AnyObject>! {
-        <#code#>
-    }
-    
-    func perform(_ aSelector: Selector!, with object: Any!) -> Unmanaged<AnyObject>! {
-        <#code#>
-    }
-    
-    func perform(_ aSelector: Selector!, with object1: Any!, with object2: Any!) -> Unmanaged<AnyObject>! {
-        <#code#>
-    }
-    
-    func isProxy() -> Bool {
-        <#code#>
-    }
-    
-    func isKind(of aClass: AnyClass) -> Bool {
-        <#code#>
-    }
-    
-    func isMember(of aClass: AnyClass) -> Bool {
-        <#code#>
-    }
-    
-    func conforms(to aProtocol: Protocol) -> Bool {
-        <#code#>
-    }
-    
-    func responds(to aSelector: Selector!) -> Bool {
-        <#code#>
-    }
-    
-    var description: String {
-        <#code#>
-    }
-    
-    func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+    func ad(_ ad: FullScreenPresentingAd,
+            didFailToPresentFullScreenContentWithError error: Error) {
         rewardCompletion?(false)
         rewardCompletion = nil
         rewardedAd = nil
@@ -105,7 +54,6 @@ extension AdService: FullScreenContentDelegate {
 
     func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
         if rewardCompletion != nil {
-            // Ad dismissed without reward
             rewardCompletion?(false)
             rewardCompletion = nil
         }


### PR DESCRIPTION
## Summary
- extend `AdService` from `NSObject` to satisfy delegate requirements
- clean up `FullScreenContentDelegate` conformance

## Testing
- `swiftc -o /tmp/AdService Services/AdService.swift` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_6850982a871883219c5bbf6a3bb46a7f